### PR TITLE
Fix for newer versions of React Native

### DIFF
--- a/components/cell.js
+++ b/components/cell.js
@@ -1,11 +1,11 @@
 import React, { Component } from 'react';
-import { View, Text, StyleSheet } from 'react-native';
+import { View, ViewPropTypes, Text, StyleSheet } from 'react-native';
 
 class Cell extends Component {
   static propTypes = {
-    style: View.propTypes.style,
+    style: ViewPropTypes.style,
     textStyle: Text.propTypes.style,
-    borderStyle: View.propTypes.style,
+    borderStyle: ViewPropTypes.style,
   }
 
   render() {

--- a/components/cols.js
+++ b/components/cols.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { View, Text, StyleSheet } from 'react-native';
+import { View, ViewPropTypes, Text, StyleSheet } from 'react-native';
 import Cell from './cell';
 
 class Col extends Component {
@@ -9,7 +9,7 @@ class Col extends Component {
     heightArr: PropTypes.array,
     flexArr: PropTypes.array,
     data: PropTypes.array,
-    style: View.propTypes.style,
+    style: ViewPropTypes.style,
     textStyle: Text.propTypes.style,
   }
 
@@ -19,8 +19,8 @@ class Col extends Component {
     return (
       data ?
       <View style={[
-        width ? {width: width} : {flex: 1}, 
-        flex && {flex: flex}, 
+        width ? {width: width} : {flex: 1},
+        flex && {flex: flex},
         style
       ]}>
         {
@@ -41,7 +41,7 @@ class Cols extends Component {
     heightArr: PropTypes.array,
     flexArr: PropTypes.array,
     data: PropTypes.array,
-    style: View.propTypes.style,
+    style: ViewPropTypes.style,
     textStyle: Text.propTypes.style,
   }
 

--- a/components/rows.js
+++ b/components/rows.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { View, Text, StyleSheet } from 'react-native';
+import { View, ViewPropTypes, Text, StyleSheet } from 'react-native';
 import Cell from './cell';
 
 class Row extends Component {
@@ -8,7 +8,7 @@ class Row extends Component {
     widthArr: PropTypes.array,
     flexArr: PropTypes.array,
     data: PropTypes.array,
-    style: View.propTypes.style,
+    style: ViewPropTypes.style,
     textStyle: Text.propTypes.style,
   }
 
@@ -20,14 +20,14 @@ class Row extends Component {
           widthNum += widthArr[i];
       }
     }
-    
+
 
     return (
       data ?
       <View style={[
-        height && {height: height}, 
+        height && {height: height},
         widthNum && {width: widthNum},
-        styles.row, 
+        styles.row,
         style
       ]}>
         {
@@ -48,7 +48,7 @@ class Rows extends Component {
     widthArr: PropTypes.array,
     flexArr: PropTypes.array,
     data: PropTypes.array,
-    style: View.propTypes.style,
+    style: ViewPropTypes.style,
     textStyle: Text.propTypes.style,
   }
 

--- a/components/table.js
+++ b/components/table.js
@@ -1,10 +1,10 @@
 import React, { Component } from 'react';
-import { View, Text } from 'react-native';
+import { View, ViewPropTypes, Text } from 'react-native';
 
 class Table extends Component {
   static propTypes = {
-    style: View.propTypes.style,
-    borderStyle: View.propTypes.style,
+    style: ViewPropTypes.style,
+    borderStyle: ViewPropTypes.style,
   }
 
   _renderChildren(props) {
@@ -30,7 +30,7 @@ class Table extends Component {
       borderColor = this.props.borderStyle.borderColor;
     } else {
       borderColor = '#000';
-    }   
+    }
 
     return (
       <View style={[
@@ -49,7 +49,7 @@ class Table extends Component {
 
 class TableWrapper extends Component {
   static propTypes = {
-    style: View.propTypes.style,
+    style: ViewPropTypes.style,
   }
 
   _renderChildren(props) {


### PR DESCRIPTION
View.PropTypes is now deprecated, which means that if you try to use this module in a release build, it will crash and not work.

This commit fixes that and allows the module to work as expected (both in debug and release).